### PR TITLE
WIP: Update to 0.8

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,2 +1,2 @@
-docker==3.3.0
-jupyterhub==0.8.1
+docker>=3.3.0
+jupyterhub>=0.7.2

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,2 @@
 docker==3.3.0
-#jupyterhub==0.7.2
-jupyterhub==0.9.0
+jupyterhub==0.8.1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,2 +1,2 @@
 docker>=3.3.0
-jupyterhub>=0.7.2
+jupyterhub>=0.8.1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,2 +1,3 @@
 docker==3.3.0
-jupyterhub==0.7.2
+#jupyterhub==0.7.2
+jupyterhub==0.9.0


### PR DESCRIPTION
3 of 3: see also `docker_notebooks` and `docker_swarm_jupyterhub` (both on EDINA's GitLab)

Note that the `docker_swarm_jupyterhub` Dockerfile has a specific call to this branch, so you'll need to modify _that_ code once the merge here is accepted.